### PR TITLE
Add reason_for_visit to PatientPersona

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,4 @@
 [flake8]
 max-line-length = 120
+exclude =
+    .venv,

--- a/src/sdialog/personas.py
+++ b/src/sdialog/personas.py
@@ -371,7 +371,9 @@ class Patient(ExtendedPersona):
     """
     Patient persona with medical and health-related attributes.
 
-    :ivar symptoms: Reason for visit or chief complaint.
+    :ivar reason_for_visit: Reason for visit or chief complaint.
+    :vartype reason_for_visit: str
+    :ivar symptoms: List of symptoms or health issues.:ivar symptoms: Reason for visit or chief complaint.
     :vartype symptoms: str
     :ivar vital_signs: Vital signs of the patient.
     :vartype vital_signs: str
@@ -386,6 +388,7 @@ class Patient(ExtendedPersona):
     :ivar family_history: Family medical history.
     :vartype family_history: str
     """
+    reason_for_visit: str = ""
     symptoms: str = ""
     vital_signs: str = ""
     health_literacy: str = ""


### PR DESCRIPTION
Decouples reason_for_visit from symptoms for more precise data representation.
Additionally, it adds an exclusion for flake8 to exclude the .venv directory from code checks.