### PR TITLE
fix inference with orchestration for hf models

### DIFF
--- a/src/sdialog/personas.py
+++ b/src/sdialog/personas.py
@@ -657,9 +657,9 @@ class Agent:
             response = AIMessage(content=response)
         else:
             current_memory = self.memory_dump()
-            if len(self.memory) == 1 and (is_huggingface_model_name(self.model_uri)
-                                          or is_aws_model_name(self.model_uri)):
-                # Ensure that the first message is HumanMessage to avoid
+            if (is_huggingface_model_name(self.model_uri) or is_aws_model_name(self.model_uri)) and \
+               (not self.memory or not isinstance(self.memory[-1], HumanMessage)):
+                # Ensure that the last message is a HumanMessage to avoid
                 # "Last message must be a HumanMessage!" (huggingface)
                 # Or "A conversation must start with a user message" (aws)
                 # from langchain_huggingface (which makes no sense, for ollama is OK but for hugging face is not?)


### PR DESCRIPTION
With the current version, it is impossible to compute an inference on HF or AWS when orchestration is involved (because then, a SystemMessage will appear as the last one).